### PR TITLE
Fix types for apiRequest

### DIFF
--- a/src/http-request.js
+++ b/src/http-request.js
@@ -68,8 +68,8 @@ function HttpRequest (path, method, queryParams, body, apiKey, apiSecretKey, api
           apiRequest.set(headerKey, headers[headerKey]);
         }
       }
-
-      apiRequest.type(CL_CONSTANTS.CONTENT_TYPE_JSON);
+      const { file_name } = queryParams;
+      apiRequest.type(file_name ? mime.lookup(file_name) : CL_CONSTANTS.CONTENT_TYPE_OCTECT_STREAM);
 
       apiRequest.end(function resHandler(err, res) {
         if (err) {


### PR DESCRIPTION
Fix types for the request.
Added mime type checking by file name.
In case of default, type - stream is used.